### PR TITLE
fix: provide workaround

### DIFF
--- a/apps/react-app/project.json
+++ b/apps/react-app/project.json
@@ -42,7 +42,8 @@
           "sourceMap": false,
           "namedChunks": false,
           "extractLicenses": true,
-          "vendorChunk": false
+          "vendorChunk": false,
+          "webpackConfig": "apps/react-app/webpack.config.prod.js"
         }
       }
     },

--- a/apps/react-app/webpack.config.prod.js
+++ b/apps/react-app/webpack.config.prod.js
@@ -1,0 +1,8 @@
+const { composePlugins } = require('@nrwl/webpack');
+
+// Nx plugins for webpack.
+module.exports = composePlugins(require('./webpack.config'), (config) => {
+  // Update the webpack config as needed here.
+  process.env.BABEL_ENV = 'production';
+  return config;
+});


### PR DESCRIPTION
Provides workaround for below:

# Issue Statement

Babel envKey is not set to configuration name. This was the previous behavior in version 15.x sometime before 15.7. I'm not 100% sure when the issue started, as this is a reproduction based on a report from someone else.

## Repro steps

Run `nx serve react-app --configuration production`. Note the output is "Hello test-plugin".

Run `BABEL_ENV=production nx serve react-app`. Note the output is "Hello prod-plugin"